### PR TITLE
fix handing of test_info

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -24,7 +24,7 @@ jobs:
           command: |
             addpath("${{ github.workspace }}/k-Wave");
             cd("${{ github.workspace }}/k-Wave/testing/unit");
-            test_struct = runUnitTests("",false);
+            test_struct = runUnitTests("calculateMassSource_bowl_source",false);
             save('test_struct.mat', 'test_struct');
           startup-options: -nojvm -logfile output.log
 

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -24,7 +24,7 @@ jobs:
           command: |
             addpath("${{ github.workspace }}/k-Wave");
             cd("${{ github.workspace }}/k-Wave/testing/unit");
-            test_struct = runUnitTests("make",false);
+            test_struct = runUnitTests("pstdElastic",false);
             save('test_struct.mat', 'test_struct');
           startup-options: -nojvm -logfile output.log
 

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -24,7 +24,7 @@ jobs:
           command: |
             addpath("${{ github.workspace }}/k-Wave");
             cd("${{ github.workspace }}/k-Wave/testing/unit");
-            test_struct = runUnitTests("pstdElastic",false);
+            test_struct = runUnitTests("",false);
             save('test_struct.mat', 'test_struct');
           startup-options: -nojvm -logfile output.log
 

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -24,7 +24,7 @@ jobs:
           command: |
             addpath("${{ github.workspace }}/k-Wave");
             cd("${{ github.workspace }}/k-Wave/testing/unit");
-            test_struct = runUnitTests("kWaveDiffusion",false);
+            test_struct = runUnitTests("make",false);
             save('test_struct.mat', 'test_struct');
           startup-options: -nojvm -logfile output.log
 

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -24,7 +24,7 @@ jobs:
           command: |
             addpath("${{ github.workspace }}/k-Wave");
             cd("${{ github.workspace }}/k-Wave/testing/unit");
-            test_struct = runUnitTests("kWaveArray",false);
+            test_struct = runUnitTests("kWaveDiffusion",false);
             save('test_struct.mat', 'test_struct');
           startup-options: -nojvm -logfile output.log
 

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -2,7 +2,11 @@ name: Run unit tests
 
 on:
   push:
-
+    branches:
+       - main
+  pull_request:
+    branches:
+       - main
 
 jobs:
   unit-tests:

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -24,7 +24,7 @@ jobs:
           command: |
             addpath("${{ github.workspace }}/k-Wave");
             cd("${{ github.workspace }}/k-Wave/testing/unit");
-            test_struct = runUnitTests("acousticFieldPropagator",false);
+            test_struct = runUnitTests("angularSpectrum",false);
             save('test_struct.mat', 'test_struct');
           startup-options: -nojvm -logfile output.log
 

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -2,11 +2,7 @@ name: Run unit tests
 
 on:
   push:
-    branches:
-       - main
-  pull_request:
-    branches:
-       - main
+
 
 jobs:
   unit-tests:
@@ -28,7 +24,7 @@ jobs:
           command: |
             addpath("${{ github.workspace }}/k-Wave");
             cd("${{ github.workspace }}/k-Wave/testing/unit");
-            test_struct = runUnitTests("",false);
+            test_struct = runUnitTests("acousticFieldPropagator",false);
             save('test_struct.mat', 'test_struct');
           startup-options: -nojvm -logfile output.log
 

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -24,7 +24,7 @@ jobs:
           command: |
             addpath("${{ github.workspace }}/k-Wave");
             cd("${{ github.workspace }}/k-Wave/testing/unit");
-            test_struct = runUnitTests("",false);
+            test_struct = runUnitTests("smooth_test_delta",false);
             save('test_struct.mat', 'test_struct');
           startup-options: -nojvm -logfile output.log
 

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -24,7 +24,7 @@ jobs:
           command: |
             addpath("${{ github.workspace }}/k-Wave");
             cd("${{ github.workspace }}/k-Wave/testing/unit");
-            test_struct = runUnitTests("angularSpectrum",false);
+            test_struct = runUnitTests("kspaceFirstOrder",false);
             save('test_struct.mat', 'test_struct');
           startup-options: -nojvm -logfile output.log
 

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -24,7 +24,7 @@ jobs:
           command: |
             addpath("${{ github.workspace }}/k-Wave");
             cd("${{ github.workspace }}/k-Wave/testing/unit");
-            test_struct = runUnitTests("kspaceFirstOrder",false);
+            test_struct = runUnitTests("kWaveArray",false);
             save('test_struct.mat', 'test_struct');
           startup-options: -nojvm -logfile output.log
 

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -24,7 +24,7 @@ jobs:
           command: |
             addpath("${{ github.workspace }}/k-Wave");
             cd("${{ github.workspace }}/k-Wave/testing/unit");
-            test_struct = runUnitTests("calculateMassSource_bowl_source",false);
+            test_struct = runUnitTests("",false);
             save('test_struct.mat', 'test_struct');
           startup-options: -nojvm -logfile output.log
 

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -24,7 +24,7 @@ jobs:
           command: |
             addpath("${{ github.workspace }}/k-Wave");
             cd("${{ github.workspace }}/k-Wave/testing/unit");
-            test_struct = runUnitTests("smooth_test_delta",false);
+            test_struct = runUnitTests("",false);
             save('test_struct.mat', 'test_struct');
           startup-options: -nojvm -logfile output.log
 

--- a/k-Wave/testing/unit/runUnitTests.m
+++ b/k-Wave/testing/unit/runUnitTests.m
@@ -63,13 +63,11 @@ filenames = filenames.m;
 % remove any files that start with 'runUnitTests'
 filenames(startsWith(filenames, 'runUnitTests')) = [];
 
-% In runUnitTests.m, after getting the filenames:
-exclude_patterns = {'pstdElastic', 'make', 'kWaveDiffusion', 'kWaveArray', 'kspaceFirstOrder', 'angularSpectrum', 'acousticFieldPropagator'};
-to_keep = true(size(filenames));
-for i = 1:numel(exclude_patterns)
-    to_keep = to_keep & ~contains(filenames, exclude_patterns{i});
+% filter filenames based on wildcard if provided
+if nargin >= 1 && ~isempty(wildcard)
+    filenames = filenames(contains(filenames, wildcard));
 end
-filenames = filenames(to_keep);
+
 % extract number of files to test
 num_files = length(filenames);
 
@@ -94,16 +92,14 @@ for filename_index = 1:num_files
     disp(['Running ' fn ' (Test ' num2str(filename_index) ' of ' num2str(num_files) ')']);
 
     try
-
         % run the file and store results, capturing all printed output
         [test_info, test_pass] = evalc([fn '(' plot_simulations ',' plot_comparisons ');']);
         if isempty(strtrim(test_info))
             test_info = 'No information available';
         end
-        % print the captured output
         fprintf('%s', test_info);
         disp('  ');
-
+        
     catch %#ok<CTCH>
        
         % if the test gives an error for any reason, assign as failed

--- a/k-Wave/testing/unit/runUnitTests.m
+++ b/k-Wave/testing/unit/runUnitTests.m
@@ -63,11 +63,13 @@ filenames = filenames.m;
 % remove any files that start with 'runUnitTests'
 filenames(startsWith(filenames, 'runUnitTests')) = [];
 
-% filter filenames based on wildcard if provided
-if nargin >= 1 && ~isempty(wildcard)
-    filenames = filenames(contains(filenames, wildcard));
+% In runUnitTests.m, after getting the filenames:
+exclude_patterns = {'pstdElastic', 'make', 'kWaveDiffusion', 'kWaveArray', 'kspaceFirstOrder', 'angularSpectrum', 'acousticFieldPropagator'};
+to_keep = true(size(filenames));
+for i = 1:numel(exclude_patterns)
+    to_keep = to_keep & ~contains(filenames, exclude_patterns{i});
 end
-
+filenames = filenames(to_keep);
 % extract number of files to test
 num_files = length(filenames);
 
@@ -95,6 +97,9 @@ for filename_index = 1:num_files
 
         % run the file and store results, capturing all printed output
         [test_info, test_pass] = evalc([fn '(' plot_simulations ',' plot_comparisons ');']);
+        if isempty(strtrim(test_info))
+            test_info = 'No information available';
+        end
         % print the captured output
         fprintf('%s', test_info);
 

--- a/k-Wave/testing/unit/runUnitTests.m
+++ b/k-Wave/testing/unit/runUnitTests.m
@@ -63,10 +63,13 @@ filenames = filenames.m;
 % remove any files that start with 'runUnitTests'
 filenames(startsWith(filenames, 'runUnitTests')) = [];
 
-% filter filenames based on wildcard if provided
-if nargin >= 1 && ~isempty(wildcard)
-    filenames = filenames(contains(filenames, wildcard));
+% In runUnitTests.m, after getting the filenames:
+exclude_patterns = {'pstdElastic', 'make', 'kWaveDiffusion', 'kWaveArray', 'kspaceFirstOrder', 'angularSpectrum', 'acousticFieldPropagator'};
+to_keep = true(size(filenames));
+for i = 1:numel(exclude_patterns)
+    to_keep = to_keep & ~contains(filenames, exclude_patterns{i});
 end
+filenames = filenames(to_keep);
 
 % extract number of files to test
 num_files = length(filenames);

--- a/k-Wave/testing/unit/runUnitTests.m
+++ b/k-Wave/testing/unit/runUnitTests.m
@@ -63,13 +63,10 @@ filenames = filenames.m;
 % remove any files that start with 'runUnitTests'
 filenames(startsWith(filenames, 'runUnitTests')) = [];
 
-% In runUnitTests.m, after getting the filenames:
-exclude_patterns = {'pstdElastic', 'make', 'kWaveDiffusion', 'kWaveArray', 'kspaceFirstOrder', 'angularSpectrum', 'acousticFieldPropagator'};
-to_keep = true(size(filenames));
-for i = 1:numel(exclude_patterns)
-    to_keep = to_keep & ~contains(filenames, exclude_patterns{i});
+% filter filenames based on wildcard if provided
+if nargin >= 1 && ~isempty(wildcard)
+    filenames = filenames(contains(filenames, wildcard));
 end
-filenames = filenames(to_keep);
 
 % extract number of files to test
 num_files = length(filenames);

--- a/k-Wave/testing/unit/runUnitTests.m
+++ b/k-Wave/testing/unit/runUnitTests.m
@@ -67,12 +67,14 @@ filenames(startsWith(filenames, 'runUnitTests')) = [];
 if nargin >= 1 && ~isempty(wildcard)
     filenames = filenames(contains(filenames, wildcard));
 end
-
 % extract number of files to test
 num_files = length(filenames);
 
 % keep a list of whether the test passed or failed
 test_result = false(num_files, 1);
+
+% preallocate cell array for test_info
+test_info = cell(num_files, 1);
 
 % =========================================================================
 % RUN TESTS
@@ -83,33 +85,32 @@ for filename_index = 1:num_files
 
     % remove test pass variable
     clear test_pass;
-    
+
     % trim the .m extension
     fn = filenames{filename_index};
     fn = fn(1:end - 2);
-    
+
     % display the filename
     disp(['Running ' fn ' (Test ' num2str(filename_index) ' of ' num2str(num_files) ')']);
 
     try
         % run the file and store results, capturing all printed output
-        [test_info, test_pass] = evalc([fn '(' plot_simulations ',' plot_comparisons ');']);
-        if isempty(strtrim(test_info))
-            test_info = 'No information available';
+        [captured_output, test_pass] = evalc([fn '(' plot_simulations ',' plot_comparisons ');']);
+        if isempty(strtrim(captured_output))
+            captured_output = 'No information available';
         end
-        fprintf('%s', test_info);
+        fprintf('%s', captured_output);
         disp('  ');
-        
     catch %#ok<CTCH>
-       
         % if the test gives an error for any reason, assign as failed
         test_pass = false;
-        
+        captured_output = 'No information available';
     end
-    
-    % store test result
+
+    % store test result and info
     test_result(filename_index) = test_pass;
-    
+    test_info{filename_index} = captured_output;
+
 end
 
 % =========================================================================

--- a/k-Wave/testing/unit/runUnitTests.m
+++ b/k-Wave/testing/unit/runUnitTests.m
@@ -63,10 +63,20 @@ filenames = filenames.m;
 % remove any files that start with 'runUnitTests'
 filenames(startsWith(filenames, 'runUnitTests')) = [];
 
-% filter filenames based on wildcard if provided
-if nargin >= 1 && ~isempty(wildcard)
-    filenames = filenames(contains(filenames, wildcard));
+
+
+
+% In runUnitTests.m, after getting the filenames:
+
+
+exclude_patterns = {'pstdElastic', 'make', 'kWaveDiffusion', 'kWaveArray', 'kspaceFirstOrder', 'angularSpectrum', 'acousticFieldPropagator'};
+to_keep = true(size(filenames));
+for i = 1:numel(exclude_patterns)
+    to_keep = to_keep & ~contains(filenames, exclude_patterns{i});
 end
+
+
+filenames = filenames(to_keep);
 % extract number of files to test
 num_files = length(filenames);
 

--- a/k-Wave/testing/unit/runUnitTests.m
+++ b/k-Wave/testing/unit/runUnitTests.m
@@ -102,6 +102,7 @@ for filename_index = 1:num_files
         end
         % print the captured output
         fprintf('%s', test_info);
+        disp('  ');
 
     catch %#ok<CTCH>
        

--- a/k-Wave/testing/unit/runUnitTests.m
+++ b/k-Wave/testing/unit/runUnitTests.m
@@ -63,20 +63,10 @@ filenames = filenames.m;
 % remove any files that start with 'runUnitTests'
 filenames(startsWith(filenames, 'runUnitTests')) = [];
 
-
-
-
-% In runUnitTests.m, after getting the filenames:
-
-
-exclude_patterns = {'pstdElastic', 'make', 'kWaveDiffusion', 'kWaveArray', 'kspaceFirstOrder', 'angularSpectrum', 'acousticFieldPropagator'};
-to_keep = true(size(filenames));
-for i = 1:numel(exclude_patterns)
-    to_keep = to_keep & ~contains(filenames, exclude_patterns{i});
+% filter filenames based on wildcard if provided
+if nargin >= 1 && ~isempty(wildcard)
+    filenames = filenames(contains(filenames, wildcard));
 end
-
-
-filenames = filenames(to_keep);
 % extract number of files to test
 num_files = length(filenames);
 


### PR DESCRIPTION
**Issue**
Previously, the script used a single test_pass variable and overwrote it in each iteration. Additionally, it did not retain the printed output (`test_info`).

**Fix**
- Preallocate `test_info` arrays to store results 
- Captured and stored printed output from each test using evalc, assigning it to captured_output.
- Handle empty `test_info` cases by assigning a default message: "No information available".